### PR TITLE
Fix comments of Keyboard Mode

### DIFF
--- a/include/gtk-layer-shell.h
+++ b/include/gtk-layer-shell.h
@@ -73,11 +73,11 @@ typedef enum {
 
 /**
  * GtkLayerShellKeyboardMode:
- * GTK_LAYER_SHELL_KEYBOARD_MODE_NONE: This window should not receive keyboard events.
- * GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE: This window should have exclusive focus if it is on the top or overlay layer.
- * GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND: The user should be able to focus and unfocues this window in an implementation
+ * @GTK_LAYER_SHELL_KEYBOARD_MODE_NONE: This window should not receive keyboard events.
+ * @GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE: This window should have exclusive focus if it is on the top or overlay layer.
+ * @GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND: The user should be able to focus and unfocues this window in an implementation
  * defined way. Not supported for protocol version < 4.
- * GTK_LAYER_SHELL_KEYBOARD_MODE_ENTRY_NUMBER: Should not be used except to get the number of entries. (NOTE: may change in
+ * @GTK_LAYER_SHELL_KEYBOARD_MODE_ENTRY_NUMBER: Should not be used except to get the number of entries. (NOTE: may change in
  * future releases as more entries are added)
  */
 typedef enum {


### PR DESCRIPTION
I noticed that the automatically generated comments of the Rust bindings for the keyboard modes are not at the correct place. The only difference I noticed was the missing @ symbols. I hope that is the reason why they don't get generated correctly but I am not sure.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
